### PR TITLE
Added more example/similar to Drupal Coding Standards

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -13,3 +13,21 @@ parameters:
       directory: './src'
     phpcs:
       standard: Drupal
+      ignore_patterns:
+        - .github
+        - .gitlab
+        - bower_components
+        - node_modules
+        - vendor
+      triggered_by:
+        - php
+        - module
+        - inc
+        - install
+        - test
+        - profile
+        - theme
+        - css
+        - info
+        - txt
+        - md


### PR DESCRIPTION
Added based on [Drupal Coding Standards](https://www.drupal.org/docs/8/modules/code-review-module/php-codesniffer-command-line-usage)
- `ignore_patterns`
   - Added also `.github`-folder and `.gitlab`-folder.
- `triggered_by` 