### PR TITLE
Upgrade grumphp to the latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "drupal/coder": "^8.2.12",
     "jakub-onderka/php-parallel-lint": "^1.0",
     "localheinz/composer-normalize": "^1.2",
-    "phpro/grumphp": "^0.15",
+    "phpro/grumphp": "^0.16",
     "sebastian/phpcpd": "^3.0"
   },
   "support": {


### PR DESCRIPTION
I originally did this to fix the deprecation errors I noticed, but I see that would have been fixed even with 0.15 which was in master (but in no tag). I submitted a PR anyway to keep up the version to the latest release.

To avoid this repeatedly, should we just require `>=0.16 <1.0`?