### PR TITLE
Update PHPCPD to ^4.0 release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "jakub-onderka/php-parallel-lint": "^1.0",
     "localheinz/composer-normalize": "^1.2",
     "phpro/grumphp": "^0.15",
-    "sebastian/phpcpd": "^3.0"
+    "sebastian/phpcpd": "^4.0"
   },
   "support": {
     "issues": "https://github.com/vijaycs85/drupal-quality-checker/issues",


### PR DESCRIPTION
PHPCPD was reporting errors on one of my projects and I am thinking an upgrade would solve it. The problem is that this change requires PHP 7.1 at least. If that's not acceptable, an alternative is to change the condition to `>=3.0`.