### PR TITLE
Update Grumphp dependency and adapt config file to new version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "drupal/coder": "^8.3",
     "php-parallel-lint/php-parallel-lint": "^1.0",
     "ergebnis/composer-normalize": "^2.5",
-    "phpro/grumphp": "^0.18",
+    "phpro/grumphp": "^1.3",
     "sebastian/phpcpd": "^5.0"
   },
   "support": {

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -1,9 +1,7 @@
-parameters:
+grumphp:
   ascii:
     failed: vendor/vijaycs85/drupal-quality-checker/resources/ascii/grumpy.txt
     succeeded: vendor/vijaycs85/drupal-quality-checker/resources/ascii/happy.txt
-  git_dir: .
-  bin_dir: vendor/bin
   tasks:
     phplint: ~
     yamllint: ~


### PR DESCRIPTION
After trying to install Drupal Quality Checker in a project it failed because it require the 0.80 version for phpro/grumphp, and it didn't comply with the stability requirements. This PR updates the Grumphp version and does the required changes to the config file.